### PR TITLE
docs: fix typo & update statements

### DIFF
--- a/advanced/mode.mdx
+++ b/advanced/mode.mdx
@@ -7,7 +7,7 @@ We have two conversation modes **Hands-free** and **Hands-on**.
 
 By default interactions are initiated in **Hands-free** mode, In this mode users just talk to the AI and we automatically process the response, timing and manage the conversation responsiveness in the background.
 
-While Hands-on mode, allows users to manually determine when to send their full response to the AI.
+Hands-on mode allows users to manually determine when to send their full response to the AI.
 
 <Info>
     You can try out the Hands-on mode in the [Playground](https://app.diarupt.ai/) by changing the **Interaction Mode** control to `hands-on` in the `Advanced Controls` section.
@@ -114,4 +114,4 @@ To send user's response.
 
 ## Conclusion
 
-You're all set to use Hands-on mode. Now you control your user's conversational experience as you wish while still enjoying the benefit of our realtime video conversation AI.
+You're all set to use Hands-on mode which grants more conversational control to users and allows for more personalized interactive flow while still enjoying the benefit of our realtime video conversation AI.

--- a/core/transcripts.mdx
+++ b/core/transcripts.mdx
@@ -5,13 +5,13 @@ description: "Transcripts provide interactions logs"
 
 Transcripts are a way to provide a detailed log of the interaction between the AI and the user. This is useful for debugging, post processing and for auditing purposes.
 
-To access the intractions transcript history you can fetch a interaction session. 
+To access the interactions transcript history you can fetch an interaction session. 
 
 <Info>
 See the [Get Session API](/api/sessions/get-session) for more information.
 </Info>
 
-An Interaction transcript history would something look like this:
+Below is a snapshot of an Interaction transcript:
 
 ```json
 [
@@ -60,7 +60,7 @@ That should log the transcript to the console as it is being generated, which wo
     "timestamp": "2020-10-20T18:00:00.000Z",
     "role": "assistant",
     "content": "Hello, how can I help you?",
-    "complete": true // indicates that this is the full transcript
+    "complete": true // indicates transcript contains complete statement
 }
 ```
 


### PR DESCRIPTION
- interactions was misspelt in a couple places
- update statement grammar
- update comment explaining `complete`  parameter on transcript history